### PR TITLE
Automatically discover desk's mac address on init

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Then install all the packages using poetry install:
 
     poetry install
 
-To install this as a command avaliable from the system build the package then
+To install this as a command available from the system build the package then
 install it with pip:
 
 
@@ -54,7 +54,7 @@ install it with pip:
 Configuration
 *************
 Configuration that is not expected to change frequency can be provided via a
-YAML configuraiton file located at ``~/.config/idasen/idasen.yaml``.
+YAML configuration file located at ``~/.config/idasen/idasen.yaml``.
 
 You can use this command to initialize a new configuartion file:
 
@@ -68,7 +68,8 @@ Configuartion options:
 * ``stand_height`` - The standing height from the floor of the desk in meters.
 * ``sit_height`` - The standing height from the floor of the desk in meters.
 
-Device MAC addresses can be found using ``blueoothctl`` and blueooth adapter
+The program will try to find the device address, but if it fails, it has to be done manually.
+Device MAC addresses can be found using ``blueoothctl`` and bluetooth adapter
 names can be found with ``hcitool dev`` on linux.
 
 Usage

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -195,7 +195,12 @@ class IdasenDesk:
 
     @classmethod
     async def discover(cls) -> Optional[str]:
-        """Try to find desk's mac addr by discovering currently connected devices."""
+        """
+        Try to find the desk's MAC address by discovering currently connected devices.
+
+        Returns:
+            MAC address if found, ``None`` if not found.
+        """
         try:
             devices = await discover()
         except Exception:

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -1,4 +1,5 @@
 from bleak import BleakClient
+from bleak import discover
 from typing import Dict
 from typing import Optional
 from typing import Tuple
@@ -191,3 +192,15 @@ class IdasenDesk:
         1.0
         """
         return _bytes_to_meters(await self._client.read_gatt_char(_UUID_HEIGHT))
+
+    @classmethod
+    async def discover(cls) -> Optional[str]:
+        """Try to find desk's mac addr by discovering currently connected devices."""
+        try:
+            devices = await discover()
+        except Exception:
+            return None
+        return next(
+            (device.address for device in devices if device.name.startswith("Desk")),
+            None,
+        )

--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -103,11 +103,11 @@ async def init(args: argparse.Namespace) -> int:
         return 1
     else:
         mac = await IdasenDesk.discover()
-        if mac:
-            sys.stderr.write(f"Discovered desk's mac address: {mac}")
+        if mac is not None:
+            sys.stderr.write(f"Discovered desk's MAC address: {mac}")
             default_config["mac_address"] = mac
         else:
-            sys.stderr.write("Failed to discover desk's mac address")
+            sys.stderr.write("Failed to discover desk's MAC address")
         os.makedirs(idasen_config_directory, exist_ok=True)
         with open(idasen_config_path, "w") as f:
             f.write(
@@ -196,17 +196,16 @@ def main(args: Optional[List[str]] = None):
     from_config(args, config, parser, "stand_height")
     from_config(args, config, parser, "sit_height")
 
-    if args.sub != "init":
-        level = count_to_level(args.verbose)
+    level = count_to_level(args.verbose)
 
-        root_logger = logging.getLogger()
+    root_logger = logging.getLogger()
 
-        handler = logging.StreamHandler(stream=sys.stderr)
-        handler.setLevel(level)
-        formatter = logging.Formatter("{levelname} {name} {message}", style="{")
-        handler.setFormatter(formatter)
-        root_logger.addHandler(handler)
-        root_logger.setLevel(level)
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setLevel(level)
+    formatter = logging.Formatter("{levelname} {name} {message}", style="{")
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
 
     func = subcommand_to_callable(args.sub)
 

--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -102,6 +102,12 @@ async def init(args: argparse.Namespace) -> int:
         sys.stderr.write("Use --force to overwrite existing configuration.\n")
         return 1
     else:
+        mac = await IdasenDesk.discover()
+        if mac:
+            sys.stderr.write(f"Discovered desk's mac address: {mac}")
+            default_config["mac_address"] = mac
+        else:
+            sys.stderr.write("Failed to discover desk's mac address")
         os.makedirs(idasen_config_directory, exist_ok=True)
         with open(idasen_config_path, "w") as f:
             f.write(
@@ -210,3 +216,7 @@ def main(args: Optional[List[str]] = None):
         rc = 0
 
     sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a simple change that will try to discover the desk's mac address automatically on init.  
It took me a while to look it up when I did `init` for myself, but usually, it can be detected automatically.

Also, I've fixed some typos that I've noticed.