### PR TITLE
Allow to save multiple positions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ repo_root = os.path.abspath(os.path.join(this_dir, ".."))
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from idasen.cli import get_parser  # noqa: E402
+from idasen.cli import get_parser, DEFAULT_CONFIG  # noqa: E402
 
 # Sphinx extensions
 extensions = [
@@ -72,7 +72,7 @@ html_context = {
     "github_repo": project,
 }
 
-parser = get_parser()
+parser = get_parser(DEFAULT_CONFIG)
 with open(os.path.join(this_dir, "cli.txt"), "w") as f:
     parser.print_help(f)
 

--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -168,16 +168,16 @@ async def save(args: argparse.Namespace, config: dict) -> None:
     config["positions"][args.name] = height
     save_config(config)
 
-    sys.stdout.write(f"Saved position '{args.name}' with height: {height}m.")
+    sys.stdout.write(f"Saved position '{args.name}' with height: {height}m.\n")
 
 
 async def delete(args: argparse.Namespace, config: dict) -> None:
     position = config["positions"].pop(args.name, None)
     if position is None:
-        sys.stderr.write(f"Position with name '{args.name}' doesn't exist.")
+        sys.stderr.write(f"Position with name '{args.name}' doesn't exist.\n")
     else:
         save_config(config)
-        sys.stdout.write(f"Position with name '{args.name}' removed.")
+        sys.stdout.write(f"Position with name '{args.name}' removed.\n")
 
 
 def from_config(

--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -1,3 +1,5 @@
+import functools
+
 from . import IdasenDesk
 from typing import Callable
 from typing import List
@@ -10,33 +12,30 @@ import sys
 import voluptuous as vol
 import yaml
 
-home = os.path.expanduser("~")
-idasen_config_directory = os.path.join(home, ".config", "idasen")
-idasen_config_path = os.path.join(idasen_config_directory, "idasen.yaml")
+HOME = os.path.expanduser("~")
+IDASEN_CONFIG_DIRECTORY = os.path.join(HOME, ".config", "idasen")
+IDASEN_CONFIG_PATH = os.path.join(IDASEN_CONFIG_DIRECTORY, "idasen.yaml")
 
-default_config = {
-    "stand_height": 1.1,
-    "sit_height": 0.75,
+DEFAULT_CONFIG = {
+    "positions": {"stand": 1.1, "sit": 0.75},
     "mac_address": "AA:AA:AA:AA:AA:AA",
 }
 
-config_schema = vol.Schema(
+CONFIG_SCHEMA = vol.Schema(
     {
         "mac_address": vol.All(str, vol.Length(min=17, max=17)),
-        "stand_height": vol.All(
+        "positions": {str: vol.All(
             vol.Any(float, int),
             vol.Range(min=IdasenDesk.MIN_HEIGHT, max=IdasenDesk.MAX_HEIGHT),
-        ),
-        "sit_height": vol.All(
-            vol.Any(float, int),
-            vol.Range(min=IdasenDesk.MIN_HEIGHT, max=IdasenDesk.MAX_HEIGHT),
-        ),
+        )}
     },
     extra=False,
 )
 
+RESERVED_NAMES = {"init", "monitor", "height", "save", "delete"}
 
-def load_config(path: str = idasen_config_path) -> dict:
+
+def load_config(path: str = IDASEN_CONFIG_PATH) -> dict:
     """ Load user config. """
     try:
         with open(path, "r") as f:
@@ -44,8 +43,17 @@ def load_config(path: str = idasen_config_path) -> dict:
     except FileNotFoundError:
         return {}
 
+    # convert old config file format
+    if "positions" not in config:
+        config["positions"] = {}
+        config["positions"]["sit"] = config.pop("sit_height", DEFAULT_CONFIG["positions"]["sit"])
+        config["positions"]["stand"] = config.pop("stand_height", DEFAULT_CONFIG["positions"]["stand"])
+
+        with open(path, "w") as f:
+            yaml.dump(config, f)
+
     try:
-        return config_schema(config)
+        return CONFIG_SCHEMA(config)
     except vol.Invalid as e:
         sys.stderr.write(f"Invalid configuration: {e}\n")
         sys.exit(1)
@@ -63,23 +71,18 @@ def add_common_args(parser: argparse.ArgumentParser):
     )
 
 
-def get_parser() -> argparse.ArgumentParser:
+def get_parser(config: dict) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="ikea IDÅSEN desk control")
     sub = parser.add_subparsers(dest="sub", help="Subcommands", required=True)
 
     height_parser = sub.add_parser("height", help="Get the desk height.")
     monitor_parser = sub.add_parser("monitor", help="Monitor the desk position.")
-    sit_parser = sub.add_parser("sit", help="Move the desk to a sitting position.")
-    stand_parser = sub.add_parser("stand", help="Move the desk to a standing position.")
     init_parser = sub.add_parser("init", help="Initialize a new configuration file.")
 
-    stand_parser.add_argument(
-        "--stand-height", type=float, help="Standing height in meters."
-    )
-
-    sit_parser.add_argument(
-        "--sit-height", type=float, help="Sitting height in meters."
-    )
+    positions = config.get("positions", {})
+    for name, value in positions.items():
+        subcommand = sub.add_parser(name, help=f"Move the desk to {value}m.")
+        add_common_args(subcommand)
 
     init_parser.add_argument(
         "-f",
@@ -90,14 +93,12 @@ def get_parser() -> argparse.ArgumentParser:
 
     add_common_args(height_parser)
     add_common_args(monitor_parser)
-    add_common_args(sit_parser)
-    add_common_args(stand_parser)
 
     return parser
 
 
 async def init(args: argparse.Namespace) -> int:
-    if not args.force and os.path.isfile(idasen_config_path):
+    if not args.force and os.path.isfile(IDASEN_CONFIG_PATH):
         sys.stderr.write("Configuration file already exists.\n")
         sys.stderr.write("Use --force to overwrite existing configuration.\n")
         return 1
@@ -105,16 +106,16 @@ async def init(args: argparse.Namespace) -> int:
         mac = await IdasenDesk.discover()
         if mac is not None:
             sys.stderr.write(f"Discovered desk's MAC address: {mac}")
-            default_config["mac_address"] = mac
+            DEFAULT_CONFIG["mac_address"] = mac
         else:
             sys.stderr.write("Failed to discover desk's MAC address")
-        os.makedirs(idasen_config_directory, exist_ok=True)
-        with open(idasen_config_path, "w") as f:
+        os.makedirs(IDASEN_CONFIG_DIRECTORY, exist_ok=True)
+        with open(IDASEN_CONFIG_PATH, "w") as f:
             f.write(
                 "# https://idasen.readthedocs.io/en/latest/index.html#configuration\n"
             )
-            yaml.dump(default_config, f)
-        sys.stderr.write(f"Created new configuration file at: {idasen_config_path}")
+            yaml.dump(DEFAULT_CONFIG, f)
+        sys.stderr.write(f"Created new configuration file at: {IDASEN_CONFIG_PATH}")
 
     return 0
 
@@ -139,14 +140,9 @@ async def height(args: argparse.Namespace):
         sys.stdout.write(f"{height:.3f} meters\n")
 
 
-async def stand(args: argparse.Namespace):
+async def move_to(args: argparse.Namespace, position: float):
     async with IdasenDesk(args.mac_address) as desk:
-        await desk.move_to_target(target=args.stand_height)
-
-
-async def sit(args: argparse.Namespace):
-    async with IdasenDesk(args.mac_address) as desk:
-        await desk.move_to_target(target=args.sit_height)
+        await desk.move_to_target(target=position)
 
 
 def from_config(
@@ -172,29 +168,26 @@ def count_to_level(count: int) -> int:
     return logging.CRITICAL
 
 
-def subcommand_to_callable(sub: str) -> Callable:
+def subcommand_to_callable(sub: str, config: dict) -> Callable:
     if sub == "init":
         return init
     elif sub == "monitor":
         return monitor
-    elif sub == "sit":
-        return sit
     elif sub == "height":
         return height
-    elif sub == "stand":
-        return stand
+    elif sub in config.get("positions", {}):
+        position = config["positions"][sub]
+        return functools.partial(move_to, position=position)
     else:
         raise AssertionError(f"internal error, please report this bug {sub=}")
 
 
 def main(args: Optional[List[str]] = None):
-    parser = get_parser()
-    args = parser.parse_args(args)
     config = load_config()
+    parser = get_parser(config)
+    args = parser.parse_args(args)
 
     from_config(args, config, parser, "mac_address")
-    from_config(args, config, parser, "stand_height")
-    from_config(args, config, parser, "sit_height")
 
     level = count_to_level(args.verbose)
 
@@ -207,7 +200,7 @@ def main(args: Optional[List[str]] = None):
     root_logger.addHandler(handler)
     root_logger.setLevel(level)
 
-    func = subcommand_to_callable(args.sub)
+    func = subcommand_to_callable(args.sub, config)
 
     rc = asyncio.run(func(args))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from idasen import cli
+from idasen.cli import DEFAULT_CONFIG
 from idasen.cli import count_to_level
 from idasen.cli import from_config
 from idasen.cli import get_parser
@@ -17,7 +18,7 @@ import yaml
 
 
 def test_get_parser_smoke():
-    assert isinstance(get_parser(), argparse.ArgumentParser)
+    assert isinstance(get_parser(DEFAULT_CONFIG), argparse.ArgumentParser)
 
 
 def test_load_config_no_file():
@@ -106,7 +107,7 @@ seen_it = []
 def test_subcommand_to_callable(sub: str):
     global seen_it
 
-    func = subcommand_to_callable(sub)
+    func = subcommand_to_callable(sub, DEFAULT_CONFIG)
     assert callable(func)
     assert func not in seen_it
     seen_it.append(func)


### PR DESCRIPTION
I don't want to hijack the project, so feel free to reject my proposal.

In general, if someone doesn't want to change how to use the program - no problem, the old behavior stays the same. The new behavior is to allow users to save multiple desk positions, or just update the current one without modifying the config file manually.

This allows users to save additional positions by simply typing `idasen save position-name`. This command will save the current desk height into the config file under the desired name. No manual changes in config files involved. If the position already exists, it will be overwritten. The `idasen delete position-name` command will remove the position from the config file.

This is a work in progress - it does work, but certainly requires some polishing. If you do want it merged, I'll finish it to pass all the checks. If not, just let me know by closing this PR, and I'll just implement it in my fork.