### PR TITLE
Fix init command

### DIFF
--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -72,7 +72,8 @@ def load_config(path: str = IDASEN_CONFIG_PATH) -> dict:
             if position in RESERVED_NAMES:
                 print(
                     "Invalid configuration, "
-                    f"position with name '{position}' is a reserved name.", file=sys.stderr
+                    f"position with name '{position}' is a reserved name.",
+                    file=sys.stderr,
                 )
                 sys.exit(1)
 
@@ -142,7 +143,9 @@ async def init(args: argparse.Namespace) -> int:
                 "# https://idasen.readthedocs.io/en/latest/index.html#configuration\n"
             )
             yaml.dump(DEFAULT_CONFIG, f)
-        print(f"Created new configuration file at: {IDASEN_CONFIG_PATH}", file=sys.stderr)
+        print(
+            f"Created new configuration file at: {IDASEN_CONFIG_PATH}", file=sys.stderr
+        )
 
     return 0
 

--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -202,12 +202,16 @@ async def delete(args: argparse.Namespace, config: dict) -> int:
 
 
 def from_config(
-    args: argparse.Namespace, config: dict, parser: argparse.ArgumentParser, key: str
+    args: argparse.Namespace,
+    config: dict,
+    parser: argparse.ArgumentParser,
+    key: str,
+    raise_error: bool = True,
 ):
     if hasattr(args, key) and getattr(args, key) is None:
         if key in config:
             setattr(args, key, config[key])
-        else:
+        elif raise_error:
             parser.error(f"{key} must be provided via the CLI or the config file")
 
 
@@ -247,7 +251,7 @@ def main(args: Optional[List[str]] = None):
     parser = get_parser(config)
     args = parser.parse_args(args)
 
-    from_config(args, config, parser, "mac_address")
+    from_config(args, config, parser, "mac_address", raise_error=args.sub != "init")
 
     level = count_to_level(args.verbose)
 


### PR DESCRIPTION
I've noticed that the init command is broken and doesn't work without providing `mac_address` argument. This shouldn't fail, as the command should detect it automatically (or write a default one).  
Additionally, I've changed all `sys.stream.write` calls to `print` as they are equivalents, except that `print` calls are ended with a new line so you don't have to remember it.