### PR TITLE
stop moving if desk safety feature kicks in

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -182,8 +182,13 @@ class IdasenDesk:
                 f"{self.MIN_HEIGHT:.3f}"
             )
 
+        previous_height = await self.get_height()
+        will_move_up = target > previous_height
         while True:
             height = await self.get_height()
+            if (height < previous_height and will_move_up) or (height > previous_height and not will_move_up):
+                self._logger.info("stopped moving because desk safety feature kicked in")
+                return
             difference = target - height
             self._logger.debug(f"{target=} {height=} {difference=}")
             if abs(difference) < 0.005:  # tolerance of 0.005 meters
@@ -194,6 +199,7 @@ class IdasenDesk:
                 await self.move_up()
             elif difference < 0:
                 await self.move_down()
+            previous_height = height
 
     async def stop(self):
         """ Stop desk movement. """

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -186,8 +186,12 @@ class IdasenDesk:
         will_move_up = target > previous_height
         while True:
             height = await self.get_height()
-            if (height < previous_height and will_move_up) or (height > previous_height and not will_move_up):
-                self._logger.info("stopped moving because desk safety feature kicked in")
+            if (height < previous_height and will_move_up) or (
+                height > previous_height and not will_move_up
+            ):
+                self._logger.info(
+                    "stopped moving because desk safety feature kicked in"
+                )
                 return
             difference = target - height
             self._logger.debug(f"{target=} {height=} {difference=}")

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -186,15 +186,15 @@ class IdasenDesk:
         will_move_up = target > previous_height
         while True:
             height = await self.get_height()
+            difference = target - height
+            self._logger.debug(f"{target=} {height=} {difference=}")
             if (height < previous_height and will_move_up) or (
                 height > previous_height and not will_move_up
             ):
-                self._logger.info(
+                self._logger.warning(
                     "stopped moving because desk safety feature kicked in"
                 )
                 return
-            difference = target - height
-            self._logger.debug(f"{target=} {height=} {difference=}")
             if abs(difference) < 0.005:  # tolerance of 0.005 meters
                 self._logger.info(f"reached target of {target:.3f}")
                 await self.stop()


### PR DESCRIPTION
Hi, and thank you for your work!

I'm using this library to display a simple popup every one or two hours to move my desk up or down automatically, and I noticed an issue: if the desk encounters an obstacle and the safety feature kicks in, the library will ignore this and continue spamming `up` or `down` commands to the desk, with the desk not moving anymore neither via the library or manual controls (only solution is to force disconnect / kill the process).

Sample log which shows the issue (obstacle encountered at 1.1225m)

```
2020-11-27 16:35:04,827 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1163 difference=0.04369999999999985
2020-11-27 16:35:04,947 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1197 difference=0.0403
2020-11-27 16:35:05,069 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1228 difference=0.0371999999999999
2020-11-27 16:35:05,190 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1261 difference=0.03389999999999982
2020-11-27 16:35:05,307 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.127 difference=0.03299999999999992
2020-11-27 16:35:05,429 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1269 difference=0.03309999999999991
2020-11-27 16:35:05,547 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.126 difference=0.03400000000000003
2020-11-27 16:35:05,668 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1242999999999999 difference=0.035700000000000065
2020-11-27 16:35:05,787 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1225 difference=0.03749999999999987
2020-11-27 16:35:05,910 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1202 difference=0.039799999999999836
2020-11-27 16:35:06,027 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1168 difference=0.043199999999999905
2020-11-27 16:35:06,147 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1135 difference=0.046499999999999986
2020-11-27 16:35:06,267 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1099 difference=0.05009999999999981
2020-11-27 16:35:06,447 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.1026 difference=0.057399999999999896
2020-11-27 16:35:06,567 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0984 difference=0.06159999999999988
2020-11-27 16:35:06,688 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0942 difference=0.06579999999999986
2020-11-27 16:35:06,808 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0889 difference=0.07109999999999994
2020-11-27 16:35:06,988 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0872 difference=0.07279999999999998
2020-11-27 16:35:07,107 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0872 difference=0.07279999999999998
2020-11-27 16:35:07,227 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0872 difference=0.07279999999999998
2020-11-27 16:35:07,347 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0872 difference=0.07279999999999998
2020-11-27 16:35:07,469 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0872 difference=0.07279999999999998
2020-11-27 16:35:07,648 [__init__][DEBUG] [D6:17:3D:31:34:84] target=1.16 height=1.0872 difference=0.07279999999999998
```

Proposed solution: store the previous height value and stop moving if the current height shows that the desk has moved in the wrong direction. I thought about storing the N latest values and then evaluating the sequence but I did a few tests and this seems enough.

Thanks!