### PR TITLE
Discovery: use service UUID instead of device name

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -255,5 +255,8 @@ class IdasenDesk:
         except Exception:
             return None
 
-        return device
+        if device is None:
+            return None
+
+        return device.address
 

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -1,23 +1,21 @@
 from bleak import BleakClient
+from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
 from typing import Any
 from typing import MutableMapping
 from typing import Optional
 from typing import Tuple
 import asyncio
-import bleak
 import logging
 import sys
 import time
-
-from bleak import BleakScanner
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
 
 
 _UUID_HEIGHT: str = "99fa0021-338a-1024-8a49-009c0215f78a"
 _UUID_COMMAND: str = "99fa0002-338a-1024-8a49-009c0215f78a"
 _UUID_REFERENCE_INPUT: str = "99fa0031-338a-1024-8a49-009c0215f78a"
-_UUID_ADV_SVC: str = '99fa0001-338a-1024-8a49-009c0215f78a'
+_UUID_ADV_SVC: str = "99fa0001-338a-1024-8a49-009c0215f78a"
 
 _COMMAND_REFERENCE_INPUT_STOP: bytearray = bytearray([0x01, 0x80])
 _COMMAND_UP: bytearray = bytearray([0x47, 0x00])
@@ -38,6 +36,7 @@ def _bytes_to_meters(raw: bytearray) -> float:
     low_byte: int = int(raw[0])
     int_raw: int = (high_byte << 8) + low_byte
     return float(int_raw / 10000) + IdasenDesk.MIN_HEIGHT
+
 
 def _is_desk(device: BLEDevice, adv: AdvertisementData) -> bool:
     return _UUID_ADV_SVC in adv.service_uuids
@@ -251,7 +250,7 @@ class IdasenDesk:
         'AA:AA:AA:AA:AA:AA'
         """
         try:
-            device = await BleakScanner.find_device_by_filter(_is_desk, timeout=30)
+            device = await BleakScanner.find_device_by_filter(_is_desk)
         except Exception:
             return None
 
@@ -259,4 +258,3 @@ class IdasenDesk:
             return None
 
         return device.address
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 
-bleak = ">=0.11,<0.13"
+bleak = "^0.12"
 pyyaml = "^5.3.1"
 voluptuous = "^0.12"
 

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -164,15 +164,19 @@ async def test_fail_to_connect(caplog, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_discover_exception():
-    with mock.patch.object(bleak, "discover", side_effect=Exception) as mock_discover:
+    with mock.patch.object(
+        bleak.BleakScanner, "find_device_by_filter", side_effect=Exception
+    ) as mock_discover:
         result = await IdasenDesk.discover()
-        mock_discover.assert_awaited_once_with()
+        mock_discover.assert_awaited_once_with(idasen._is_desk)
         assert result is None
 
 
 @pytest.mark.asyncio
 async def test_discover_empty():
-    with mock.patch.object(bleak, "discover", result=[]) as mock_discover:
+    with mock.patch.object(
+        bleak.BleakScanner, "find_device_by_filter", return_value=None
+    ) as mock_discover:
         result = await IdasenDesk.discover()
-        mock_discover.assert_awaited_once_with()
+        mock_discover.assert_awaited_once_with(idasen._is_desk)
         assert result is None

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -1,6 +1,7 @@
 from asyncio import AbstractEventLoop
-from idasen import _bytes_to_meters
+from idasen import _bytes_to_meters, _is_desk
 from idasen import IdasenDesk
+from types import SimpleNamespace
 from typing import AsyncGenerator
 from typing import Callable
 from typing import Generator
@@ -180,3 +181,15 @@ async def test_discover_empty():
         result = await IdasenDesk.discover()
         mock_discover.assert_awaited_once_with(idasen._is_desk)
         assert result is None
+
+
+@pytest.mark.parametrize(
+    "adv, is_desk",
+    [
+        (SimpleNamespace(service_uuids=[]), False),
+        (SimpleNamespace(service_uuids=["foo"]), False),
+        (SimpleNamespace(service_uuids=["foo", idasen._UUID_ADV_SVC, "bar"]), True),
+    ],
+)
+def test_is_desk(adv: SimpleNamespace, is_desk: bool):
+    assert _is_desk(None, adv) is is_desk


### PR DESCRIPTION
My desk was not discovered due to having a non-standard name (which I changed through the Linak app ages ago). Change discovery to use one of the advertised service UUIDs instead.