### PR TITLE
use poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ types-PyYAML = "^6.0.12"
 idasen = "idasen.cli:main"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Per https://pypi.org/project/poetry-core/:

> Prior to the release of version 1.1.0, Poetry was a project management tool that included a PEP 517 build backend. This was inefficient and time consuming when a PEP 517 build was required. For example, both pip and tox (with isolated builds) would install Poetry and all dependencies it required. Most of these dependencies are not required when the objective is to simply build either a source or binary distribution of your project.
>
> In order to improve the above situation, poetry-core was created. Shared functionality pertaining to PEP 517 build backends, including reading pyproject.toml and building wheel/sdist, were implemented in this package. This makes PEP 517 builds extremely fast for Poetry managed packages.