### PR TITLE
Add support for init with a BLEDevice

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".tox"]
 pygments_style = "sphinx"
 todo_include_todos = True
 nitpicky = True
+nitpick_ignore = [("py:class", "bleak.backends.device.BLEDevice")]
 
 # HTML Options
 html_theme = "sphinx_rtd_theme"

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import MutableMapping
 from typing import Optional
 from typing import Tuple
+from typing import Union
 import asyncio
 import logging
 import sys
@@ -56,7 +57,7 @@ class IdasenDesk:
     Idasen desk.
 
     Args:
-        mac: Bluetooth MAC address of the desk.
+        mac: Bluetooth MAC address of the desk, or an instance of a BLEDevice.
         exit_on_fail: If set to True, failing to connect will call ``sys.exit(1)``,
             otherwise the exception will be raised.
 
@@ -83,13 +84,13 @@ class IdasenDesk:
     #: Number of times to retry upon failure to connect.
     RETRY_COUNT: int = 3
 
-    def __init__(self, mac: str, exit_on_fail: bool = False):
-        self._logger = _DeskLoggingAdapter(
-            logger=logging.getLogger(__name__), extra={"mac": mac}
-        )
-        self._mac = mac
+    def __init__(self, mac: Union[BLEDevice, str], exit_on_fail: bool = False):
         self._exit_on_fail = exit_on_fail
-        self._client = BleakClient(self._mac)
+        self._client = BleakClient(mac)
+        self._mac = mac.address if isinstance(mac, BLEDevice) else mac
+        self._logger = _DeskLoggingAdapter(
+            logger=logging.getLogger(__name__), extra={"mac": self.mac}
+        )
 
     async def __aenter__(self):
         await self._connect()

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -20,6 +20,11 @@ def event_loop() -> Generator[AbstractEventLoop, None, None]:
     loop.close()
 
 
+# Switch this to a real mac address if you want to do live testing.
+# This will wear out your motors faster than normal usage.
+desk_mac: str = "AA:AA:AA:AA:AA:AA"
+
+
 class MockBleakClient:
     """Mocks the bleak client for unit testing."""
 
@@ -57,10 +62,9 @@ class MockBleakClient:
         high_byte = (norm >> 8) & 0xFF
         return bytearray([low_byte, high_byte, 0x00, 0x00])
 
-
-# Switch this to a real mac address if you want to do live testing.
-# This will wear out your motors faster than normal usage.
-desk_mac: str = "AA:AA:AA:AA:AA:AA"
+    @property
+    def address(self) -> str:
+        return desk_mac
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
I am developing an Home Assistant integration using this library and this is required for the library to be used in Home Assistant.

I also have a few other PRs comming for the lib to be able to be used in an Home Assistant integration.
I was trying to split them in small PRs for easier review, but I can also make it all in one bigger PR (with all the branch `ha_v1`).
