### PR TITLE
Use asyncio sleep

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -11,7 +11,6 @@ from typing import Union
 import asyncio
 import logging
 import sys
-import time
 
 
 _UUID_HEIGHT: str = "99fa0021-338a-1024-8a49-009c0215f78a"
@@ -116,7 +115,7 @@ class IdasenDesk:
                 self._logger.warning(
                     f"Failed to connect, retrying ({i}/{self.RETRY_COUNT})..."
                 )
-                time.sleep(0.3 * i)
+                await asyncio.sleep(0.3 * i)
 
     async def monitor(self, callback: Callable[[float], Awaitable[None]]):
         output_service_uuid = "99fa0020-338a-1024-8a49-009c0215f78a"

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -10,7 +10,6 @@ import asyncio
 import bleak
 import idasen
 import pytest
-import time
 
 
 @pytest.fixture(scope="session")
@@ -154,8 +153,8 @@ async def test_fail_to_connect(caplog, monkeypatch):
     async def raise_exception(*_):
         raise Exception
 
-    # patch `time.sleep()` to prevent making the tests unnecessarily long.
-    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    # patch `asyncio.sleep()` to prevent making the tests unnecessarily long.
+    monkeypatch.setattr(asyncio, "sleep", mock.AsyncMock())
 
     caplog.set_level("WARNING")
 


### PR DESCRIPTION
`asyncio.sleep()` avoids blocking the event loop.