### PR TITLE
Implement pair()

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -111,6 +111,16 @@ class IdasenDesk:
     async def __aexit__(self, *args, **kwargs):
         await self.disconnect()
 
+    async def pair(self):
+        """
+        Pair with the desk.
+
+        This method is not available on macOS. Instead of manually initiating
+        paring, the user will be prompted to pair automatically as soon as it
+        is required.
+        """
+        await self._client.pair()
+
     async def connect(self):
         """
         Connect to the desk.

--- a/idasen/cli.py
+++ b/idasen/cli.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=False,
 )
 
-RESERVED_NAMES = {"init", "monitor", "height", "save", "delete"}
+RESERVED_NAMES = {"init", "pair", "monitor", "height", "save", "delete"}
 
 
 def save_config(config: dict, path: str = IDASEN_CONFIG_PATH):
@@ -107,6 +107,7 @@ def get_parser(config: dict) -> argparse.ArgumentParser:
     monitor_parser = sub.add_parser("monitor", help="Monitor the desk position.")
     init_parser = sub.add_parser("init", help="Initialize a new configuration file.")
     save_parser = sub.add_parser("save", help="Save current desk position.")
+    pair_parser = sub.add_parser("pair", help="Pair with device.")
     save_parser.add_argument("name", help="Position name")
     delete_parser = sub.add_parser("delete", help="Remove position with given name.")
     delete_parser.add_argument("name", help="Position name")
@@ -124,6 +125,7 @@ def get_parser(config: dict) -> argparse.ArgumentParser:
     )
 
     add_common_args(init_parser)
+    add_common_args(pair_parser)
     add_common_args(height_parser)
     add_common_args(monitor_parser)
     add_common_args(save_parser)
@@ -153,6 +155,11 @@ async def init(args: argparse.Namespace) -> int:
         )
 
     return 0
+
+
+async def pair(args: argparse.Namespace) -> None:
+    async with IdasenDesk(args.mac_address, exit_on_fail=True) as desk:
+        await desk.pair()
 
 
 async def monitor(args: argparse.Namespace) -> None:
@@ -239,6 +246,8 @@ def count_to_level(count: int) -> int:
 def subcommand_to_callable(sub: str, config: dict) -> Callable:
     if sub == "init":
         return init
+    elif sub == "pair":
+        return pair
     elif sub == "monitor":
         return monitor
     elif sub == "height":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,7 +136,7 @@ seen_it = []
 
 
 @pytest.mark.parametrize(
-    "sub", ["init", "monitor", "sit", "height", "stand", "save", "delete"]
+    "sub", ["init", "pair", "monitor", "sit", "height", "stand", "save", "delete"]
 )
 def test_subcommand_to_callable(sub: str):
     global seen_it
@@ -178,7 +178,7 @@ def test_main_internal_error():
 
 
 @pytest.mark.parametrize(
-    "sub", ["init", "monitor", "sit", "height", "stand", "add", "delete", None]
+    "sub", ["init", "pair", "monitor", "sit", "height", "stand", "add", "delete", None]
 )
 def test_main_version(sub: Optional[str]):
     with mock.patch.object(

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -107,6 +107,15 @@ def test_mac(desk: IdasenDesk):
     assert desk.mac == desk_mac
 
 
+async def test_pair(desk: IdasenDesk):
+    if desk_mac != "AA:AA:AA:AA:AA:AA":
+        return
+
+    desk._client.pair = mock.AsyncMock()  # type: ignore
+    await desk.pair()
+    desk._client.pair.assert_called_once()
+
+
 async def test_up(desk: IdasenDesk):
     initial = await desk.get_height()
     await desk.move_up()


### PR DESCRIPTION
This allows pairing without having to do it manually from the bluetooth manager.
It is also needed for the Home Assistant integration to properly work.