### PR TITLE
Interrupt movement routine when desk stops moving

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -300,7 +300,7 @@ class IdasenDesk:
         async def do_move():
             previous_height = await self.get_height()
             will_move_up = target > previous_height
-            last_move_time: float | None = None
+            last_move_time: Optional[float] = None
             while True:
                 height = await self.get_height()
                 difference = target - height

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -11,6 +11,7 @@ from typing import Union
 import asyncio
 import logging
 import sys
+import time
 
 
 _UUID_HEIGHT: str = "99fa0021-338a-1024-8a49-009c0215f78a"
@@ -299,6 +300,7 @@ class IdasenDesk:
         async def do_move():
             previous_height = await self.get_height()
             will_move_up = target > previous_height
+            last_move_time: float | None = None
             while True:
                 height = await self.get_height()
                 difference = target - height
@@ -310,6 +312,20 @@ class IdasenDesk:
                         "stopped moving because desk safety feature kicked in"
                     )
                     return
+
+                if height == previous_height:
+                    if (
+                        last_move_time is not None
+                        and time.time() - last_move_time > 0.5
+                    ):
+                        self._logger.warning(
+                            "desk is not moving anymore. physical button probably "
+                            "pressed"
+                        )
+                        return
+                else:
+                    last_move_time = time.time()
+
                 if not self._moving:
                     return
 


### PR DESCRIPTION
If the desk button is pressed while the desk is being moved from the library, the desk
stops. Without this change the lib will keep sending movement commands and the desk
would not be controllable anymore, until those commands are interrupted.

This change makes it so that the lib automatically detects that movement has seized
and so stops sending commands.
