### PR TITLE
contrib(systemd): add systemd user service examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,14 @@ Assuming the config file is populated to move the desk to sitting position:
 
     idasen sit
 
+systemd user timer
+============
+
+It can be useful to setup a systemd user timer to trigger ``idasen [sit|stand]`` periodically.
+
+See the ``contrib/systemd`` folder for examples.
+
+
 Community
 *********
 

--- a/contrib/systemd/ikea-idasen-sit.service
+++ b/contrib/systemd/ikea-idasen-sit.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Send 'sit' command to IKEA IDÅSEN desk
+After=bluetooth.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/idasen sit
+
+[Install]
+WantedBy=default.target

--- a/contrib/systemd/ikea-idasen-sit.timer
+++ b/contrib/systemd/ikea-idasen-sit.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Trigger 'sit' command on IKEA IDÅSEN desk every first quarter every hour between 8 AM and 22 PM
+
+[Timer]
+OnCalendar=*-*-* 08..22:15:00
+
+[Install]
+WantedBy=timers.target

--- a/contrib/systemd/ikea-idasen-stand.service
+++ b/contrib/systemd/ikea-idasen-stand.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Send 'stand' command to IKEA IDÅSEN desk
+After=bluetooth.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/idasen stand
+
+[Install]
+WantedBy=default.target

--- a/contrib/systemd/ikea-idasen-stand.timer
+++ b/contrib/systemd/ikea-idasen-stand.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Trigger 'stand' command on IKEA IDÅSEN desk every hour between 8 AM and 22 PM
+
+[Timer]
+OnCalendar=*-*-* 08..22:00:00
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Currently using these systemd user timers and services on my workstation to automate [the balance between sitting and standing](https://ergomotion.com.au/standing-desk-blog/how-long-should-you-stand-sit-stand-desk/) (as constantly using the CLI and/or the Android app is quite annoying) and think it'll be useful to others.