### PR TITLE
Fixed not stopping when moving; Fixed interrupted moving

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -339,9 +339,9 @@ class IdasenDesk:
 
             data = _meters_to_bytes(target)
 
-            while True:
+            while self._moving:
                 await self._client.write_gatt_char(_UUID_REFERENCE_INPUT, data)
-                await asyncio.sleep(0.4)
+                await asyncio.sleep(0.2)
 
                 # Stop as soon as the speed is 0,
                 # which means the desk has reached the target position


### PR DESCRIPTION
After my PR #396 I noticed that my desk is not stopping anymore if pressing stop in Home Assistant. The moving of the desk is also sometimes interrupted. These changes fix these issues, I tested it with Home Assistant and everything seems to be working smoothly again.

I had a local implementation for my own desk which I was using before and the sleep was necessary, but it does not seem to be necessary with the Bleak Bluetooth library.