### PR TITLE
Added speed to public api (get and monitor)

### DIFF
--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -339,9 +339,9 @@ class IdasenDesk:
 
             data = _meters_to_bytes(target)
 
-            while True:
+            while self._moving:
                 await self._client.write_gatt_char(_UUID_REFERENCE_INPUT, data)
-                await asyncio.sleep(0.4)
+                await asyncio.sleep(0.2)
 
                 # Stop as soon as the speed is 0,
                 # which means the desk has reached the target position

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,7 +177,8 @@ seen_it = []
 
 
 @pytest.mark.parametrize(
-    "sub", ["init", "pair", "monitor", "sit", "height", "stand", "save", "delete"]
+    "sub",
+    ["init", "pair", "monitor", "sit", "height", "speed", "stand", "save", "delete"],
 )
 def test_subcommand_to_callable(sub: str):
     global seen_it
@@ -219,7 +220,19 @@ def test_main_internal_error():
 
 
 @pytest.mark.parametrize(
-    "sub", ["init", "pair", "monitor", "sit", "height", "stand", "add", "delete", None]
+    "sub",
+    [
+        "init",
+        "pair",
+        "monitor",
+        "sit",
+        "height",
+        "speed",
+        "stand",
+        "add",
+        "delete",
+        None,
+    ],
 )
 def test_main_version(sub: Optional[str]):
     with mock.patch.object(


### PR DESCRIPTION
Following #409, this PR makes the speed value of the desk public api. You can either:
- Use `get_speed` to get the current speed
- Use `get_height_and_speed` to get a tuple of both height and speed
- Monitor with a callback with two parameters, height and speed

For backwards compatbility you can still monitor with a callback that only accepts one parameter, which just gets called for height changes.