### PR TITLE
switch away from old "toml" module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,10 @@ import datetime
 import inspect
 import os
 import sys
-import toml
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.abspath(os.path.join(this_dir, ".."))
@@ -45,8 +48,8 @@ extensions = [
 templates_path = []
 source_suffix = ".rst"
 
-with open(os.path.join(repo_root, "pyproject.toml"), "r") as f:
-    pyproject = toml.load(f)
+with open(os.path.join(repo_root, "pyproject.toml"), "rb") as f:
+    pyproject = tomllib.load(f)
 
 # The master toctree document.
 master_doc = "index"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ import datetime
 import inspect
 import os
 import sys
+
 try:
     import tomllib
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "ruff>=0.9.1",
     "sphinx>=7.4.7",
     "sphinx-rtd-theme>=3.0.2",
-    "tomli;python_version<3.11",
+    "tomli;python_version<'3.11'",
     "types-pyyaml>=6.0.12.20241230",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "ruff>=0.9.1",
     "sphinx>=7.4.7",
     "sphinx-rtd-theme>=3.0.2",
-    "toml>=0.10.2",
+    "tomli;python_version<3.11",
     "types-pyyaml>=6.0.12.20241230",
 ]
 


### PR DESCRIPTION
Hi,

We are slowly removing older libraries from Debian.

From Python 3.11 an external library is not even needed anymore.

https://wiki.debian.org/Python/Backports

Greetings