### PR TITLE
fix: tolerant arrival detection in move_to_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed the CLI ignoring the `XDG_CONFIG_HOME` environment variable.
+- Fixed `move_to_target` exiting prematurely on transient `speed == 0`
+  readings, which could leave the desk short of its target height,
+  especially over Bluetooth proxies.
 
 ### Changed
 - Changed the build system from poetry-core to setuptools.

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -390,6 +390,10 @@ class IdasenDesk:
                     consecutive_zero_speed += 1
                 else:
                     consecutive_zero_speed = 0
+                    # Forward progress clears the stall budget so a long
+                    # move that pauses several times along the way is
+                    # not aborted prematurely.
+                    stall_retries = 0
 
                 # Treat the desk as stopped only after several consecutive
                 # ``speed == 0`` readings.  A single ``speed == 0`` sample

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -27,6 +27,26 @@ _COMMAND_DOWN: bytearray = bytearray([0x46, 0x00])
 _COMMAND_STOP: bytearray = bytearray([0xFF, 0x00])
 _COMMAND_WAKEUP: bytearray = bytearray([0xFE, 0x00])
 
+# Reference input write interval during ``move_to_target``.
+# Shorter than the historic 200ms to keep the desk controller from stalling
+# between writes when latency varies (e.g. over Bluetooth proxies).
+_MOVE_LOOP_INTERVAL: float = 0.1
+
+# Distance in meters considered "at target" for arrival detection.
+_MOVE_HEIGHT_TOLERANCE: float = 0.005
+
+# Number of consecutive ``speed == 0`` readings required before treating the
+# desk as stopped.  Filters out transient ``speed == 0`` samples that can
+# occur mid-travel (e.g. controller momentarily decelerating between
+# reference input writes, or BLE proxy latency between samples).
+_MOVE_CONSECUTIVE_ZERO_SPEED: int = 2
+
+# Maximum number of stall recoveries before giving up.  A stall is a run of
+# consecutive ``speed == 0`` readings while the desk is not at the target
+# height.  Bounded retries let the loop recover from transient pauses
+# without spinning forever if the desk is physically stuck.
+_MOVE_MAX_STALL_RETRIES: int = 3
+
 
 # height calculation offset in meters, assumed to be the same for all desks
 def _bytes_to_meters_and_speed(raw: bytearray) -> Tuple[float, float]:
@@ -349,7 +369,7 @@ class IdasenDesk:
 
         async def do_move() -> None:
             current_height = await self.get_height()
-            if current_height == target:
+            if abs(current_height - target) < _MOVE_HEIGHT_TOLERANCE:
                 return
 
             # Wakeup and stop commands are needed in order to
@@ -358,16 +378,36 @@ class IdasenDesk:
             await self._client.write_gatt_char(_UUID_COMMAND, _COMMAND_STOP)
 
             data = _meters_to_bytes(target)
+            consecutive_zero_speed = 0
+            stall_retries = 0
 
             while self._moving:
                 await self._client.write_gatt_char(_UUID_REFERENCE_INPUT, data)
-                await asyncio.sleep(0.2)
+                await asyncio.sleep(_MOVE_LOOP_INTERVAL)
 
-                # Stop as soon as the speed is 0,
-                # which means the desk has reached the target position
-                speed = await self.get_speed()
+                height, speed = await self.get_height_and_speed()
                 if speed == 0:
-                    break
+                    consecutive_zero_speed += 1
+                else:
+                    consecutive_zero_speed = 0
+
+                # Treat the desk as stopped only after several consecutive
+                # ``speed == 0`` readings.  A single ``speed == 0`` sample
+                # mid-travel can happen when the controller momentarily
+                # decelerates between writes, or when the reading races a
+                # write; exiting on the first zero would stop movement
+                # prematurely.
+                if consecutive_zero_speed >= _MOVE_CONSECUTIVE_ZERO_SPEED:
+                    if abs(height - target) < _MOVE_HEIGHT_TOLERANCE:
+                        break
+                    # Stalled away from the target.  Allow a bounded
+                    # number of stall recoveries before giving up; this
+                    # lets the loop ride out transient pauses while still
+                    # exiting if the desk is physically stuck.
+                    stall_retries += 1
+                    if stall_retries >= _MOVE_MAX_STALL_RETRIES:
+                        break
+                    consecutive_zero_speed = 0
 
         self._move_task = asyncio.create_task(do_move())
         await self._move_task

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -307,6 +307,62 @@ async def test_move_to_target_stalled_away_from_target_aborts():
         assert not desk.is_moving
 
 
+async def test_move_to_target_recovers_from_multiple_stalls():
+    """Multiple stall-recover cycles in one move must not abort the loop.
+
+    A long move over a BLE proxy can have the controller pause several
+    times along the way.  Each pause is a stall, but forward progress
+    between pauses must reset the stall budget so the move completes.
+    """
+    desk = IdasenDesk(mac=desk_mac)
+    client = MockBleakClient()
+    desk._client = client
+    client._height = 1.0
+    client.write_gatt_char = mock.AsyncMock()
+
+    # Alternate stall and movement samples: four distinct stalls (each
+    # cleared by a non-zero-speed sample) before arriving at the target.
+    # Each "stall" must be at least ``_MOVE_CONSECUTIVE_ZERO_SPEED``
+    # consecutive zero-speed readings to trip the stall-retry guard.
+    samples: list[tuple[float, float]] = [
+        (0.95, 0.0),
+        (0.95, 0.0),
+        (0.90, 0.5),
+        (0.85, 0.0),
+        (0.85, 0.0),
+        (0.80, 0.5),
+        (0.75, 0.0),
+        (0.75, 0.0),
+        (0.72, 0.5),
+        (0.71, 0.0),
+        (0.71, 0.0),
+        (0.70, 0.5),
+        (0.70, 0.0),
+        (0.70, 0.0),
+    ]
+    samples_iter = iter(samples)
+
+    async def read_gatt_char_mock(uuid: str) -> bytearray:  # noqa: ARG001
+        height, speed = next(samples_iter)
+        client._height = height
+        height_bytes = _meters_to_bytes(height)
+        speed_raw = int(speed * 10000)
+        return bytearray(
+            [height_bytes[0], height_bytes[1], speed_raw & 0xFF, speed_raw >> 8]
+        )
+
+    client.read_gatt_char = read_gatt_char_mock
+
+    async with desk:
+        await desk.move_to_target(0.7)
+        assert not desk.is_moving
+        # If the stall budget had not been reset between recoveries the
+        # loop would have aborted before consuming all samples.  We
+        # consumed exactly the number of samples expected for arrival.
+        with pytest.raises(StopIteration):
+            next(samples_iter)
+
+
 @pytest.mark.parametrize(
     "raw, height, speed",
     [

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -244,6 +244,69 @@ async def test_move_stop():
         assert move_task.done()
 
 
+async def test_move_to_target_already_at_target_with_tolerance():
+    """A height within the tolerance of the target is treated as already there."""
+    desk = IdasenDesk(mac=desk_mac)
+    client = MockBleakClient()
+    desk._client = client
+    # 4 mm above the target is within the 5 mm arrival tolerance.
+    client._height = 0.704
+
+    async with desk:
+        await desk.move_to_target(0.7)
+        # No reference input writes should have happened.
+        assert client._height == 0.704
+
+
+async def test_move_to_target_tolerates_transient_zero_speed():
+    """A single ``speed == 0`` mid-travel must not stop the loop."""
+    desk = IdasenDesk(mac=desk_mac)
+    client = MockBleakClient()
+    desk._client = client
+    client._height = 1.0
+    client.write_gatt_char = mock.AsyncMock()
+
+    # Speeds returned by consecutive get_height_and_speed() calls.  The
+    # first reading reports ``speed == 0`` (transient), then movement
+    # resumes, and finally ``speed == 0`` at the target.
+    speeds_iter = iter([0.0, 0.5, 0.0, 0.0])
+    heights_iter = iter([0.95, 0.85, 0.7, 0.7])
+
+    async def read_gatt_char_mock(uuid: str) -> bytearray:  # noqa: ARG001
+        height = next(heights_iter)
+        speed = next(speeds_iter)
+        client._height = height
+        height_bytes = _meters_to_bytes(height)
+        speed_raw = int(speed * 10000)
+        return bytearray(
+            [height_bytes[0], height_bytes[1], speed_raw & 0xFF, speed_raw >> 8]
+        )
+
+    client.read_gatt_char = read_gatt_char_mock
+
+    async with desk:
+        await desk.move_to_target(0.7)
+        # Loop must have run at least 4 iterations (one per speed sample)
+        # before exiting at the target.
+        assert not desk.is_moving
+
+
+async def test_move_to_target_stalled_away_from_target_aborts():
+    """If the desk repeatedly stalls away from the target, the loop aborts."""
+    desk = IdasenDesk(mac=desk_mac)
+    client = MockBleakClient()
+    desk._client = client
+    client._height = 1.0
+    # The mock client's read_gatt_char reports speed 0 when _is_moving is
+    # False; combined with the height never reaching the target, the loop
+    # must exit via the stall-retry guard rather than hanging.
+    client.write_gatt_char = mock.AsyncMock()
+
+    async with desk:
+        await desk.move_to_target(0.7)
+        assert not desk.is_moving
+
+
 @pytest.mark.parametrize(
     "raw, height, speed",
     [


### PR DESCRIPTION
## Summary

Make `move_to_target` resilient to transient `speed == 0` readings during travel by:

- requiring multiple consecutive `speed == 0` readings before treating the desk as stopped
- checking the height is within a small tolerance of the target on stop, rather than just relying on speed
- allowing a bounded number of stall recoveries by re-sending the reference input
- reducing the reference input write interval from 200ms to 100ms

## Why

The current loop exits as soon as `get_speed()` returns 0:

```python
while self._moving:
    await self._client.write_gatt_char(_UUID_REFERENCE_INPUT, data)
    await asyncio.sleep(0.2)
    speed = await self.get_speed()
    if speed == 0:
        break
```

That works most of the time over a direct BLE connection, but in practice the desk controller can briefly read `speed == 0` mid-travel — for example when it momentarily decelerates between reference input writes, or when the speed read races a write. Exiting on the first zero stops movement early and leaves the desk short of its target.

The effect is much worse over Bluetooth proxies (e.g. ESPHome Bluetooth proxies used by the Home Assistant `idasen_desk` integration), where ATT round-trips can spike to hundreds of milliseconds, transient `speed == 0` samples become common, and the 200ms write interval can starve the controller of reference input and cause it to physically stop and restart several times per move.

## Changes

In `move_to_target`:

- Use `get_height_and_speed()` instead of `get_speed()` so both values are available
- Require `_MOVE_CONSECUTIVE_ZERO_SPEED = 2` consecutive `speed == 0` readings before considering stopping
- When that threshold is reached, only break if the height is within `_MOVE_HEIGHT_TOLERANCE = 0.005` m of the target; otherwise increment a stall counter and continue
- After `_MOVE_MAX_STALL_RETRIES = 3` stalls, give up to preserve the existing "abort when the desk does not move" behavior
- Reduce the reference input write interval to `_MOVE_LOOP_INTERVAL = 0.1` s
- Treat "already at target" with the same tolerance to avoid pointless no-op moves

All new constants are module-level so they are easy to find and tune.

## Tests

- All existing tests continue to pass (including `test_move_to_target`, `test_move_abort_when_no_movement`, `test_move_stop`)
- New `test_move_to_target_already_at_target_with_tolerance` covers the tolerance path on the initial height check
- New `test_move_to_target_tolerates_transient_zero_speed` exercises a transient `speed == 0` mid-travel followed by recovery
- New `test_move_to_target_stalled_away_from_target_aborts` covers the stall-retry guard ensuring the loop exits when the desk never reaches the target

Local CI checks:

```
$ uv run ruff check
All checks passed!
$ uv run ruff format --check
7 files already formatted
$ uv run mypy idasen tests
Success: no issues found in 5 source files
$ uv run pytest -vvv --cov=idasen --doctest-modules
91 passed
```

## Notes

- No public API change. Callers that use `move_to_target` see the same interface and the same `is_moving` semantics.
- The 200ms historical interval was occasionally enough time for the DPG1C controller to decelerate between writes; 100ms is closer to the cadence used by other Linak-compatible projects and removed the observable pauses in my own testing.
- Reported behavior for the Home Assistant `idasen_desk` integration matches this pattern: see [home-assistant/core#155912](https://github.com/home-assistant/core/issues/155912) and [abmantis/idasen-ha#38](https://github.com/abmantis/idasen-ha/pull/38) for downstream context.