### PR TITLE
feat: optional client argument to IdasenDesk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added an optional ``client`` argument to ``IdasenDesk.__init__`` for
-  injecting a pre-configured ``BleakClient``. Useful for downstream
+- Added an optional `client` argument to `IdasenDesk.__init__` for
+  injecting a pre-configured `BleakClient`. Useful for downstream
   wrappers that manage their own connection lifecycle (e.g. via
-  ``bleak-retry-connector``). When provided, ``disconnected_callback``
+  `bleak-retry-connector`). When provided, `disconnected_callback`
   is ignored.
 
 ## [0.13.0] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added an optional ``client`` argument to ``IdasenDesk.__init__`` for
+  injecting a pre-configured ``BleakClient``. Useful for downstream
+  wrappers that manage their own connection lifecycle (e.g. via
+  ``bleak-retry-connector``). When provided, ``disconnected_callback``
+  is ignored.
+
 ## [0.13.0] - 2026-05-25
 ### Fixed
 - Fixed the CLI ignoring the `XDG_CONFIG_HOME` environment variable.

--- a/idasen/__init__.py
+++ b/idasen/__init__.py
@@ -94,7 +94,15 @@ class IdasenDesk:
         disconnected_callback:
             Callback that will be scheduled in the event loop when the client is
             disconnected. The callable must take one argument, which will be
-            this client object.
+            this client object. Ignored when ``client`` is provided; in that
+            case the caller is responsible for configuring the disconnected
+            callback on the injected client.
+        client:
+            Optional pre-configured :class:`bleak.BleakClient` to use instead
+            of letting :class:`IdasenDesk` create one internally.  Useful for
+            downstream wrappers that manage their own connection lifecycle
+            (e.g. via ``bleak-retry-connector``).  When provided,
+            ``disconnected_callback`` is ignored.
 
     Note:
         There is no locking to prevent you from running multiple movement
@@ -124,12 +132,16 @@ class IdasenDesk:
         mac: Union[BLEDevice, str],
         exit_on_fail: bool = False,
         disconnected_callback: Optional[Callable[[BleakClient], None]] = None,
+        client: Optional[BleakClient] = None,
     ):
         self._exit_on_fail = exit_on_fail
-        self._client = BleakClient(
-            address_or_ble_device=mac,
-            disconnected_callback=disconnected_callback,
-        )
+        if client is None:
+            self._client = BleakClient(
+                address_or_ble_device=mac,
+                disconnected_callback=disconnected_callback,
+            )
+        else:
+            self._client = client
         self._mac = mac.address if isinstance(mac, BLEDevice) else mac
         self._logger = _DeskLoggingAdapter(
             logger=logging.getLogger(__name__), extra={"mac": self.mac}

--- a/tests/test_idasen.py
+++ b/tests/test_idasen.py
@@ -107,6 +107,35 @@ def test_mac(desk: IdasenDesk):
     assert desk.mac == desk_mac
 
 
+def test_init_creates_default_client():
+    """Without ``client``, ``__init__`` creates its own ``BleakClient``."""
+    desk = IdasenDesk(mac=desk_mac)
+    assert isinstance(desk._client, bleak.BleakClient)
+
+
+def test_init_uses_injected_client():
+    """An injected ``client`` is used as-is, with no replacement."""
+    injected = MockBleakClient()
+    desk = IdasenDesk(mac=desk_mac, client=injected)  # type: ignore[arg-type]
+    assert desk._client is injected
+
+
+def test_init_ignores_disconnected_callback_when_client_provided():
+    """``disconnected_callback`` is ignored when ``client`` is provided.
+
+    The caller is expected to configure the disconnected callback on the
+    client they pass in.
+    """
+    injected = MockBleakClient()
+    callback = mock.Mock()
+    desk = IdasenDesk(
+        mac=desk_mac,
+        client=injected,  # type: ignore[arg-type]
+        disconnected_callback=callback,
+    )
+    assert desk._client is injected
+
+
 async def test_pair(desk: IdasenDesk):
     if desk_mac != "AA:AA:AA:AA:AA:AA":
         return


### PR DESCRIPTION
## Summary

Add an optional `client: BleakClient | None = None` parameter to `IdasenDesk.__init__`. When provided, the supplied client is used as-is instead of letting the constructor create its own; otherwise the existing behavior is preserved.

## Why

Downstream wrappers that manage their own BLE connection lifecycle currently have to subclass `IdasenDesk` (or reach into `_client`) to swap out the underlying `BleakClient`. The most common case is using [`bleak-retry-connector`](https://github.com/Bluetooth-Devices/bleak-retry-connector)'s `establish_connection()`, which returns a pre-connected client with caching and retry logic — useful for connections through Bluetooth proxies.

Letting `IdasenDesk` accept a pre-configured client removes the need for subclassing and makes the relationship explicit rather than fragile.

This was requested by [`abmantis/idasen-ha`](https://github.com/abmantis/idasen-ha/pull/41#issuecomment-4488797413), which is the Home Assistant helper library that wraps this package.

## Changes

In `IdasenDesk.__init__`:

- Add `client: Optional[BleakClient] = None` argument
- If `client` is `None`, the existing branch runs — a fresh `BleakClient` is created with the supplied `disconnected_callback`
- If `client` is provided, it is stored as `self._client` as-is; `disconnected_callback` is ignored on the assumption that the caller has already configured it on the client they pass in (documented in the docstring)
- `self._mac` is still derived from the `mac` argument so logging is unchanged

No other code paths are modified.

## Tests

- `test_init_creates_default_client` — without `client`, a `BleakClient` is created
- `test_init_uses_injected_client` — when `client` is provided, the same instance is stored on `self._client`
- `test_init_ignores_disconnected_callback_when_client_provided` — `disconnected_callback` is silently ignored when `client` is provided

All existing tests continue to pass.

Local CI checks:

```
$ uv run ruff check
All checks passed!
$ uv run ruff format --check
7 files already formatted
$ uv run mypy idasen tests
Success: no issues found in 5 source files
$ uv run pytest -vvv --cov=idasen --doctest-modules
95 passed
```

## Notes

- No behavior change for callers that don't pass `client`
- Companion to #489 (the tolerant arrival detection fix in 0.13.0) — both improvements are needed by the Home Assistant integration to drop a downstream subclass.